### PR TITLE
Run tests in python27 and fix _format_errors method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+  - "2.7"
   - "3.4"
   - "3.5"
 install: pip install tox-travis

--- a/channels_api/bindings.py
+++ b/channels_api/bindings.py
@@ -3,6 +3,7 @@ import json
 from channels.binding import websockets
 from channels.binding.base import CREATE, UPDATE, DELETE
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import six
 
 from rest_framework.exceptions import APIException, NotFound
 
@@ -86,7 +87,7 @@ class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
     def _format_errors(self, errors):
         if isinstance(errors, list):
             return errors
-        elif isinstance(errors, str):
+        elif isinstance(errors, six.string_types):
             return [errors]
         elif isinstance(errors, dict):
             return [errors]

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,5 +1,6 @@
 import json
 
+from django.utils.encoding import force_text
 from rest_framework import serializers
 
 from channels.message import pending_message_store
@@ -28,12 +29,12 @@ class TestModelResourceBinding(bindings.ResourceBinding):
 class ResourceBindingTestCase(ChannelTestCase):
 
     def setUp(self):
-        super().setUp()
+        super(ResourceBindingTestCase, self).setUp()
         self.client = Client()
 
     def _send_and_consume(self, channel, data):
         """Helper that sends and consumes message and returns the next message."""
-        self.client.send_and_consume(channel, data)
+        self.client.send_and_consume(force_text(channel), data)
         return self._get_next_message()
 
     def _get_next_message(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+  {py27}-django-{18,19,110}
   {py34}-django-{18,19,110}
   {py35}-django-{18,19,110}
 


### PR DESCRIPTION
empty message was sent in python 2.7 for `unicode` or `basestring` types