### PR TITLE
Return subscribed action in SubscribeModelMixin

### DIFF
--- a/channels_api/mixins.py
+++ b/channels_api/mixins.py
@@ -65,9 +65,10 @@ class SubscribeModelMixin(object):
 
         if 'action' not in data:
             raise ValidationError('action required')
-        group_name = self._group_name(data['action'], id=pk)
+        action = data['action']
+        group_name = self._group_name(action, id=pk)
         Group(group_name).add(self.message.reply_channel)
-        return {}, 200
+        return {'action': action}, 200
 
 
 class SerializerMixin(object):

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -195,7 +195,9 @@ class ResourceBindingTestCase(ChannelTestCase):
         expected_response = {
             'action': 'subscribe',
             'request_id': 'client-request-id',
-            'data': {},
+            'data': {
+                'action': 'create'
+             },
             'errors': [],
             'response_status': 200
         }


### PR DESCRIPTION
So that we can easily identify the subscribed actions (and eventually the errors) when subscribing multiple actions at the same time.