### PR TITLE
Fix retrieve action with invalid pk values: return 404 status

### DIFF
--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -182,6 +182,21 @@ class ResourceBindingTestCase(ChannelTestCase):
         }
         self.assertEqual(json_content['payload'], expected)
 
+    def test_retrieve_invalid_pk_404(self):
+        json_content = self._send_and_consume('websocket.receive', self._build_message('testmodel', {
+            'action': 'retrieve',
+            'pk': 'invalid-pk-value',
+            'request_id': 'client-request-id'
+        }))
+        expected = {
+            'action': 'retrieve',
+            'data': None,
+            'errors': ['Not found.'],
+            'response_status': 404,
+            'request_id': 'client-request-id'
+        }
+        self.assertEqual(json_content['payload'], expected)
+
     def test_subscribe(self):
 
         json_content = self._send_and_consume('websocket.receive', self._build_message("testmodel",{


### PR DESCRIPTION
before this change, an unhandled ValueError was raised.

- Rely on rest_framework.generics.get_object_or_404 for error management
- catch the Http404 exception to transform it into APIException