### PR TITLE
Add custom actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,10 +244,67 @@ with the parameters to filter
     }
   }
 
+
+Custom Actions
+--------------
+
+To add your own custom actions, use the ``detail_action`` or ``list_action``
+decorators.
+
+
+.. code:: python
+
+    from channels_api.bindings import ResourceBinding
+    from channels_api.decorators import detail_action, list_action
+
+    from .models import Question
+    from .serializers import QuestionSerializer
+
+    class QuestionBinding(ResourceBinding):
+
+        model = Question
+        stream = "questions"
+        serializer_class = QuestionSerializer
+        queryset = Question.objects.all()
+
+        @detail_action()
+        def publish(self, pk, data=None, **kwargs):
+            instance = self.get_object(pk)
+            result = instance.publish()
+            return result, 200
+
+        @list_action()
+        def report(self, data=None, **kwargs):
+            report = self.get_queryset().build_report()
+            return report, 200
+
+Then pass the method name as "action" in your message
+
+.. code:: javascript
+
+  // run the publish() custom action on Question 1
+  var msg = {
+    stream: "questions",
+    payload: {
+      action: "publish",
+      data: {
+        pk: "1"
+      }
+    }
+  }
+
+  // run the report() custom action on all Questions
+  var msg = {
+    stream: "questions",
+    payload: {
+      action: "report"
+    }
+  }
+
+
 Roadmap
 -------
 
 -  0.4
     -  Permissions
-    -  Custom Methods
     -  Test Project

--- a/channels_api/bindings.py
+++ b/channels_api/bindings.py
@@ -1,7 +1,7 @@
 import json
 
 from channels.binding import websockets
-from channels.binding.base import CREATE, UPDATE, DELETE
+from channels.binding.base import CREATE, UPDATE, DELETE, BindingMetaclass
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import six
 
@@ -11,9 +11,29 @@ from .mixins import SerializerMixin, SubscribeModelMixin, CreateModelMixin, Upda
     RetrieveModelMixin, ListModelMixin, DeleteModelMixin
 
 
+class ResourceBindingMetaclass(BindingMetaclass):
+    """
+    Metaclass that records action methods
+    """
+
+    def __new__(cls, name, bases, body):
+        binding = super(ResourceBindingMetaclass, cls).__new__(cls, name, bases, body)
+
+        binding.available_actions = {}
+        for methodname in dir(binding):
+            attr = getattr(binding, methodname)
+            is_action = getattr(attr, 'action', False)
+            if is_action:
+                kwargs = getattr(attr, 'kwargs', {})
+                name = kwargs.get('name', methodname)
+                binding.available_actions[name] = methodname
+
+        return binding
+
+
+@six.add_metaclass(ResourceBindingMetaclass)
 class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
 
-    available_actions = ('create', 'retrieve', 'list', 'update', 'delete', 'subscribe')
     fields = []  # hack to pass cls.register() without ValueError
     queryset = None
     # mark as abstract
@@ -114,15 +134,17 @@ class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
         try:
             if not self.has_permission(self.user, action, pk):
                 self.reply(action, errors=['Permission Denied'], status=401)
-            elif not action in self.available_actions:
+            elif action not in self.available_actions:
                 self.reply(action, errors=['Invalid Action'], status=400)
             else:
-                if action in ('create', 'list'):
-                    data, status = getattr(self, action)(data)
-                elif action in ('retrieve', 'delete'):
-                    data, status = getattr(self, action)(pk)
-                elif action in ('update', 'subscribe'):
-                    data, status = getattr(self, action)(pk, data)
+                methodname = self.available_actions[action]
+                method = getattr(self, methodname)
+                detail = getattr(method, 'detail', True)
+                if detail:
+                    rv = method(pk, data=data)
+                else:
+                    rv = method(data=data)
+                data, status = rv
                 self.reply(action, data=data, status=status, request_id=self.request_id)
         except APIException as ex:
             self.reply(action, errors=self._format_errors(ex.detail), status=ex.status_code, request_id=self.request_id)

--- a/channels_api/decorators.py
+++ b/channels_api/decorators.py
@@ -1,0 +1,22 @@
+def detail_action(**kwargs):
+    """
+    Used to mark a method on a ResourceBinding that should be routed for detail actions.
+    """
+    def decorator(func):
+        func.action = True
+        func.detail = True
+        func.kwargs = kwargs
+        return func
+    return decorator
+
+
+def list_action(**kwargs):
+    """
+    Used to mark a method on a ResourceBinding that should be routed for list actions.
+    """
+    def decorator(func):
+        func.action = True
+        func.detail = False
+        func.kwargs = kwargs
+        return func
+    return decorator

--- a/channels_api/mixins.py
+++ b/channels_api/mixins.py
@@ -2,11 +2,13 @@ from channels import Group
 from django.core.paginator import Paginator
 from rest_framework.exceptions import ValidationError
 
+from .decorators import detail_action, list_action
 from .settings import api_settings
 
 class CreateModelMixin(object):
     """Mixin class that handles the creation of an object using a DRF serializer."""
 
+    @list_action()
     def create(self, data, **kwargs):
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
@@ -18,6 +20,7 @@ class CreateModelMixin(object):
 
 class RetrieveModelMixin(object):
 
+    @detail_action()
     def retrieve(self, pk, **kwargs):
         instance = self.get_object_or_404(pk)
         serializer = self.get_serializer(instance)
@@ -26,6 +29,7 @@ class RetrieveModelMixin(object):
 
 class ListModelMixin(object):
 
+    @list_action()
     def list(self, data, **kwargs):
         if not data:
             data = {}
@@ -38,6 +42,7 @@ class ListModelMixin(object):
 
 class UpdateModelMixin(object):
 
+    @detail_action()
     def update(self, pk, data, **kwargs):
         instance = self.get_object_or_404(pk)
         serializer = self.get_serializer(instance, data=data)
@@ -51,6 +56,7 @@ class UpdateModelMixin(object):
 
 class DeleteModelMixin(object):
 
+    @detail_action()
     def delete(self, pk, **kwargs):
         instance = self.get_object_or_404(pk)
         self.perform_delete(instance)
@@ -61,6 +67,7 @@ class DeleteModelMixin(object):
 
 class SubscribeModelMixin(object):
 
+    @detail_action()
     def subscribe(self, pk, data, **kwargs):
 
         if 'action' not in data:


### PR DESCRIPTION
Custom actions were implemented using two decorators, `detail_action` and `list_action`, to mirror DRF's [`detail_route` and `list_route`](http://www.django-rest-framework.org/api-guide/routers/#extra-link-and-actions). These decorators simply mark the methods with attributes (like DRF), which are collected by a metaclass into `YourResourceBinding.available_actions` as a mapping from action name to method name — a name can be passed to the decorators to set an action name which is different from the method name (like DRF's `url_path` parameter).

I would've rather not used a metaclass, but there's no explicit Router instantiation, as with DRF, where processing of the actions could occur. But channels' `ResourceBinding` uses a metaclass, so there was precedent :P

Note: `available_actions` was changed from a tuple to a dict, which is part of the public API. The arguments passed to action methods also changed, so subclasses which overrode `retrieve` or `delete` would have to start accepting either a `data` param or `**kwargs`.

I'm happy to make changes if you've got any criticism! Cheers :)