### PR TITLE
Add request_id on action failure

### DIFF
--- a/channels_api/bindings.py
+++ b/channels_api/bindings.py
@@ -143,9 +143,11 @@ class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
     def run_action(self, action, pk, data):
         try:
             if not self.has_permission(self.user, action, pk):
-                self.reply(action, errors=['Permission Denied'], status=401)
+                self.reply(action, errors=['Permission Denied'], status=401,
+                           request_id=self.request_id)
             elif action not in self.available_actions:
-                self.reply(action, errors=['Invalid Action'], status=400)
+                self.reply(action, errors=['Invalid Action'], status=400,
+                           request_id=self.request_id)
             else:
                 methodname = self.available_actions[action]
                 method = getattr(self, methodname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django
 djangorestframework
--e git@github.com:django/channels.git#egg=channels
+-e git+git@github.com:django/channels.git#egg=channels

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -414,7 +414,7 @@ class ResourceBindingTestCase(ChannelTestCase):
             }
 
             self.assertEqual(json_content['payload'], expected)
-            mock_has_perm.assert_called()
+            self.assertEqual(mock_has_perm.called, True)
 
     def test_bad_action_reply(self):
         json_content = self._send_and_consume('websocket.receive', self._build_message('testmodel',{


### PR DESCRIPTION
Noticed this when trying to work with channels-api in a personal project. It'll help with routing the response to the correct error handler.

Tests included.