### PR TITLE
Permissions: allow action if found a "good" user

### DIFF
--- a/channels_api/__init__.py
+++ b/channels_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from .decorators import detail_action, list_action
 from .permissions import AllowAny, IsAuthenticated, IsSuperuser

--- a/channels_api/__init__.py
+++ b/channels_api/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "0.4.0"
 
 from .decorators import detail_action, list_action
-from .permissions import AllowAny, IsAuthenticated
+from .permissions import AllowAny, IsAuthenticated, IsSuperuser

--- a/channels_api/bindings.py
+++ b/channels_api/bindings.py
@@ -102,15 +102,18 @@ class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
             return "{}-{}".format(self.model_label, action)
 
     def has_permission(self, user, action, pk):
+        permissions = api_settings.DEFAULT_PERMISSION_CLASSES
+        for cls in permissions:
+            if cls().has_permission(user, action, pk):
+                return True
+
         if self.permission_classes:
             permissions = self.permission_classes
-        else:
-            permissions = api_settings.DEFAULT_PERMISSION_CLASSES
+            for cls in permissions:
+                if cls().has_permission(user, action, pk):
+                    return True
 
-        for cls in permissions:
-            if not cls().has_permission(user, action, pk):
-                return False
-        return True
+        return False
 
     def filter_queryset(self, queryset):
         return queryset

--- a/channels_api/permissions.py
+++ b/channels_api/permissions.py
@@ -16,3 +16,9 @@ class IsAuthenticated(BasePermission):
 
     def has_permission(self, user, action, pk):
         return user.pk and user.is_authenticated
+
+
+class IsSuperuser(BasePermission):
+
+    def has_permission(self, user, action, pk):
+        return user.is_superuser

--- a/channels_api/settings.py
+++ b/channels_api/settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from rest_framework.settings import APISettings
 
 DEFAULTS = {
+    'CHECK_ALL_PERMISSIONS': True,
     'DEFAULT_PAGE_SIZE': 25,
     'DEFAULT_PERMISSION_CLASSES': (
         'channels_api.permissions.AllowAny',


### PR DESCRIPTION
Permsissions work very wierd for me. I want to specify everyone who is allowed to do "action".
But instead channels api looks for at least one permission that fails and returns False.

Example 1:

```
    permission_classes = (
        IsSuperuser,
        IsAuthor,
    )
```

Of course I want to allow Superuser and Author to do something. But how it works now:

If I'm Superuser but not Author - I'm not allowed to do something. So I need to be both Superuser and Author. That's wierd!

Example 2:

```
# settings.py
CHANNELS_API = {
    'DEFAULT_PERMISSION_CLASSES': ('channels_api.permissions.IsSuperuser', ),
}
```

If I define that by default I allow anything for a Superuser - I do not want to check anything else if I'm a Superuser.

### So

During permission checking if I found a user that is allowed to do something why the hell do I need to check something else? Just return True.

I was surprised finding that permissions work this way.

In future maybe some integration with [Guardian](https://github.com/django-guardian/django-guardian) or [rules](https://github.com/dfunckt/django-rules) will be good.