### PR TITLE
Update readme to include bindings within celery tasks example, Update support for channels v1.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,29 @@ Started <https://channels.readthedocs.io/en/latest/getting-started.html>`__
 
 That's it. You can now make REST WebSocket requests to the server.
 
+
+-  Bindings within asyncronous tasks using celery (Optional)
+
+To ensure bindings are properly connected to model instances used
+within celery tasks, create a celery function to initialize the bindings
+on celeryd_init.connect
+
+.. code:: Python
+
+    # polls/tasks.py
+    from celery.signals import celeryd_init
+
+    @celeryd_init.connect
+    def register_model_bindings(**kwargs):
+        binding = QuestionBinding
+        model = binding.model
+
+        pre_save.connect(binding.pre_save_receiver, sender=model)
+        post_save.connect(binding.post_save_receiver, sender=model)
+        pre_delete.connect(binding.pre_delete_receiver, sender=model)
+        post_delete.connect(binding.post_delete_receiver, sender=model)
+
+
 .. code:: javascript
 
     var ws = new WebSocket("ws://" + window.location.host + "/")
@@ -155,28 +178,6 @@ That's it. You can now make REST WebSocket requests to the server.
         request_id: "some-guid"
       }
     }
-
--  Bindings within asyncronous tasks using celery (Optional)
-
-To ensure bindings are properly connected to model instances used
-within celery tasks, create a celery function to initialize the bindings
-on celeryd_init.connect
-
-.. code:: Python
-
-    # polls/tasks.py
-    from celery.signals import celeryd_init
-
-    @celeryd_init.connect
-    def register_model_bindings(**kwargs):
-        binding = QuestionBinding
-        model = binding.model
-
-        pre_save.connect(binding.pre_save_receiver, sender=model)
-        post_save.connect(binding.post_save_receiver, sender=model)
-        pre_delete.connect(binding.pre_delete_receiver, sender=model)
-        post_delete.connect(binding.post_delete_receiver, sender=model)
-
 
 -  Add the channels debugger page (Optional)
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ channels. It provides a ``ResourceBinding`` which is comparable to Django
 Rest Framework's ``ModelViewSet``. It is based on DRF serializer
 classes.
 
-It requires Python 2.7 or 3.x, Channels >0.17.3, Django >1.8, and Django Rest Framework 3.0
+It requires Python 2.7 or 3.x, Channels 1.x > 0.17.3 , Django >1.8, and Django Rest Framework 3.0
 
 You can learn more about channels-api from my talk at the `SF Django Meetup <https://vimeo.com/194110172#t=3033>`__ or `PyBay 2016 <https://www.youtube.com/watch?v=HzC_pUhoW0I>`__
 

--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,28 @@ That's it. You can now make REST WebSocket requests to the server.
       }
     }
 
+-  Bindings within asyncronous tasks using celery (Optional)
+
+To ensure bindings are properly connected to model instances used
+within celery tasks, create a celery function to initialize the bindings
+on celeryd_init.connect
+
+.. code:: Python
+
+    # polls/tasks.py
+    from celery.signals import celeryd_init
+
+    @celeryd_init.connect
+    def register_model_bindings(**kwargs):
+        binding = QuestionBinding
+        model = binding.model
+
+        pre_save.connect(binding.pre_save_receiver, sender=model)
+        post_save.connect(binding.post_save_receiver, sender=model)
+        pre_delete.connect(binding.pre_delete_receiver, sender=model)
+        post_delete.connect(binding.post_delete_receiver, sender=model)
+
+
 -  Add the channels debugger page (Optional)
 
 This page is helpful to debug API requests from the browser and see the

--- a/README.rst
+++ b/README.rst
@@ -122,29 +122,6 @@ Started <https://channels.readthedocs.io/en/latest/getting-started.html>`__
 
 That's it. You can now make REST WebSocket requests to the server.
 
-
--  Bindings within asyncronous tasks using celery (Optional)
-
-To ensure bindings are properly connected to model instances used
-within celery tasks, create a celery function to initialize the bindings
-on celeryd_init.connect
-
-.. code:: Python
-
-    # polls/tasks.py
-    from celery.signals import celeryd_init
-
-    @celeryd_init.connect
-    def register_model_bindings(**kwargs):
-        binding = QuestionBinding
-        model = binding.model
-
-        pre_save.connect(binding.pre_save_receiver, sender=model)
-        post_save.connect(binding.post_save_receiver, sender=model)
-        pre_delete.connect(binding.pre_delete_receiver, sender=model)
-        post_delete.connect(binding.post_delete_receiver, sender=model)
-
-
 .. code:: javascript
 
     var ws = new WebSocket("ws://" + window.location.host + "/")
@@ -178,6 +155,28 @@ on celeryd_init.connect
         request_id: "some-guid"
       }
     }
+
+-  Bindings within asyncronous tasks using celery (Optional)
+
+To ensure bindings are properly connected to model instances used
+within celery tasks, create a celery function to initialize the bindings
+on celeryd_init.connect
+
+.. code:: Python
+
+    # polls/tasks.py
+    from celery.signals import celeryd_init
+
+    @celeryd_init.connect
+    def register_model_bindings(**kwargs):
+        binding = QuestionBinding
+        model = binding.model
+
+        pre_save.connect(binding.pre_save_receiver, sender=model)
+        post_save.connect(binding.post_save_receiver, sender=model)
+        pre_delete.connect(binding.pre_delete_receiver, sender=model)
+        post_delete.connect(binding.post_delete_receiver, sender=model)
+
 
 -  Add the channels debugger page (Optional)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django
 djangorestframework
--e git+git@github.com:django/channels.git#egg=channels
+-e git+git@github.com:django/channels.git@1.x#egg=channels


### PR DESCRIPTION
Thanks so much for this project! It was extremely helpful and the missing piece I was searching for!

I updated the Readme to include how to get model bindings to work with model instances within celery tasks.

I also updated the Reame and requirements.txt to indicate support for only channels 1.x, as channels 2.x has dropped the binding framework alltogether (see http://channels.readthedocs.io/en/latest/one-to-two.html#removed-components)

