### PR TITLE
Add queryset and lookup_field to BasePermissions

### DIFF
--- a/channels_api/bindings.py
+++ b/channels_api/bindings.py
@@ -108,7 +108,7 @@ class ResourceBindingBase(SerializerMixin, websockets.WebsocketBinding):
             permissions = api_settings.DEFAULT_PERMISSION_CLASSES
 
         for cls in permissions:
-            if not cls().has_permission(user, action, pk):
+            if not cls(self.filter_queryset(self.queryset), self.lookup_field).has_permission(user, action, pk):
                 return False
         return True
 

--- a/channels_api/permissions.py
+++ b/channels_api/permissions.py
@@ -1,6 +1,10 @@
 
 
 class BasePermission(object):
+    
+    def __init__(self, queryset, lookup_field):
+        self.queryset = queryset
+        self.lookup_field = lookup_field
 
     def has_permission(self, user, action, pk):
         pass


### PR DESCRIPTION
#44 Adds a queryset and lookup_field to BasePermission so that you can query on your models in custom permissions classes. Passes all tests in runtests.py and solves the issue mentioned in #44 