### PR TITLE
Update requirements to use a compatible version of channels (1.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django
 djangorestframework
--e git+git@github.com:django/channels.git#egg=channels
+-e git+git@github.com:django/channels.git@1.x#egg=channels


### PR DESCRIPTION
#46 This changes requirements.txt to use a compatible version of channels instead of 2.0 as requirements.txt currently installs. All tests pass in this commit.