### PR TITLE
Missing `url` module import in `urls.py` example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ response. It is only designed to be used when ``DEBUG=TRUE``.
 
     # proj/urls.py
 
-    from django.conf.urls import include
+    from django.conf.urls import url, include
 
         urlpatterns = [
             url(r'^channels-api/', include('channels_api.urls'))


### PR DESCRIPTION
Just a quick fix to the Readme or update on your end and close this PR. 

- Missing `url` module import in `urls.py` example

p.s. Thanks for maintaining this!